### PR TITLE
changed api call search limit and added dedupe function to results

### DIFF
--- a/search.js
+++ b/search.js
@@ -13,22 +13,14 @@ const options = {
     lang: 'en'
 };
 
-function removeDuplicates(array, prop) {
-  return array.filter((obj, pos, arr) => {
-    return arr.map(mapObj => mapObj[prop]).indexOf(obj[prop] === pos)
-  })
-}
-
 function searchBooks(query, page) {
   options.offset = !page || page === 1 ? 0 : offsetForPage(page, SEARCH_LIMIT)
   return new Promise(function (resolve, reject) {
     books.search(query, options, function(err, results) {
-      let googleBooks = [];
       if (err) {
         return reject(err)
       } else {
-        googleBooks = removeDuplicates(results, results.id);
-        return resolve(googleBooks.slice(0, 9));
+        return resolve(_.uniqBy(results, 'id').slice(0, 9));
       }
     })
   })

--- a/search.js
+++ b/search.js
@@ -3,7 +3,7 @@ const books = require('google-books-search');
 const Promise = require('bluebird')
 const _ = require('lodash')
 
-const SEARCH_LIMIT = 9
+const SEARCH_LIMIT = 36
 const options = {
     key: config.API_KEY,
     offset: 0,
@@ -13,17 +13,25 @@ const options = {
     lang: 'en'
 };
 
+function removeDuplicates(array, prop) {
+  return array.filter((obj, pos, arr) => {
+    return arr.map(mapObj => mapObj[prop]).indexOf(obj[prop] === pos)
+  })
+}
+
 function searchBooks(query, page) {
   options.offset = !page || page === 1 ? 0 : offsetForPage(page, SEARCH_LIMIT)
   return new Promise(function (resolve, reject) {
     books.search(query, options, function(err, results) {
+      let googleBooks = [];
       if (err) {
         return reject(err)
       } else {
         _.map(results, book => {
-          console.log(options.offset, book.id, book.title, book.authors, book.industryIdentifiers)
-        })
-        return resolve(results)
+          console.log(options.offset, book.id, book.title, book.authors, book.industryIdentifiers);
+        });
+        googleBooks = removeDuplicates(results, results.id);
+        return resolve(googleBooks.slice(0, 9));
       }
     })
   })

--- a/search.js
+++ b/search.js
@@ -28,7 +28,7 @@ function searchBooks(query, page) {
         return reject(err)
       } else {
         _.map(results, book => {
-          console.log(options.offset, book.id, book.title, book.authors, book.industryIdentifiers);
+            (options.offset, book.id, book.title, book.authors, book.industryIdentifiers);
         });
         googleBooks = removeDuplicates(results, results.id);
         return resolve(googleBooks.slice(0, 9));

--- a/search.js
+++ b/search.js
@@ -27,9 +27,6 @@ function searchBooks(query, page) {
       if (err) {
         return reject(err)
       } else {
-        _.map(results, book => {
-            (options.offset, book.id, book.title, book.authors, book.industryIdentifiers);
-        });
         googleBooks = removeDuplicates(results, results.id);
         return resolve(googleBooks.slice(0, 9));
       }

--- a/server.js
+++ b/server.js
@@ -64,7 +64,6 @@ app.post('/api/readinglist/books/add', jsonParser, (req, res) => {
 });
 
 app.post('/api/search', jsonParser, (req, res) => {
-  console.log('req.body:', req.body)
   if (!req.body.query) {
     return res.status(400).send('no query in request body');
   }

--- a/test/test-search.js
+++ b/test/test-search.js
@@ -1,23 +1,34 @@
-const chai = require('chai');
-const chaiHttp = require('chai-http');
-
-const expect = chai.expect;
-
-const {app, runServer, closeServer} = require('../server');
-const {TEST_DATABASE_URL} = require('../config');
+const chai = require('chai')
+const chaiHttp = require('chai-http')
+const expect = chai.expect
+const {app, runServer, closeServer} = require('../server')
+const {TEST_DATABASE_URL} = require('../config')
 
 chai.use(chaiHttp);
 
 describe('Search API resource', function() {
   before(function() {
     return runServer(TEST_DATABASE_URL);
-  });
+  })
+
   after(function() {
     return closeServer();
-  });
+  })
+
   describe('Search POST endpoint', function() {
     let page1BookIds = []
     let page2BookIds = []
+
+    it('should error on empty POST', function() {
+      return chai.request(app)
+      .post('/api/search')
+      .send({})
+      .then(function(res) {
+        expect(res).to.have.status(400);
+        expect(res.text).to.equal('no query in request body')
+      })
+    })
+
     it('should return results on POST', function() {
       return chai.request(app)
       .post('/api/search')
@@ -31,7 +42,7 @@ describe('Search API resource', function() {
           page1BookIds.push(book.industryIdentifiers[0].identifier)
         })
       })
-    });
+    })
 
     it('should return page 2 results on POST', function() {
       return chai.request(app)
@@ -42,21 +53,10 @@ describe('Search API resource', function() {
         expect(res.body).to.be.a('array')
         expect(res.body.length).to.equal(9)
         res.body.forEach(book => {
-          expect(book).to.include.keys(['authors', 'title', 'thumbnail', 'industryIdentifiers'])
           page2BookIds.push(book.industryIdentifiers[0].identifier)
         })
         expect(page2BookIds).to.not.have.members(page1BookIds)
       })
-    });
-
-    it('should error on empty POST', function() {
-      return chai.request(app)
-      .post('/api/search')
-      .send({})
-      .then(function(res) {
-        expect(res).to.have.status(400);
-        expect(res.text).to.equal('no query in request body')
-      })
-    });
-  });
-});
+    })
+  })
+})


### PR DESCRIPTION
API search limit changed to 36 (highest allowed) with a de-dupe function running on the full array. Then displaying 9 at a time to the client.